### PR TITLE
no Java class corresponding to class Array found error

### DIFF
--- a/src/main/scala/mesosphere/jackson/CaseClassValueInstantiator.scala
+++ b/src/main/scala/mesosphere/jackson/CaseClassValueInstantiator.scala
@@ -63,8 +63,6 @@ protected class CaseClassValueInstantiator(
 
     ListMap(applySymbol.paramss.flatten.zipWithIndex.map {
       case (p, i) =>
-        val typeSig = p.asTerm.typeSignature.typeSymbol.asClass
-        val cls = classLoaderMirror.runtimeClass(typeSig)
         p.name.toString -> valueFor(i)
     }: _*)
   }

--- a/src/main/scala/mesosphere/jackson/CaseClassValueInstantiator.scala
+++ b/src/main/scala/mesosphere/jackson/CaseClassValueInstantiator.scala
@@ -63,6 +63,10 @@ protected class CaseClassValueInstantiator(
 
     ListMap(applySymbol.paramss.flatten.zipWithIndex.map {
       case (p, i) =>
+        val typeSig = p.asTerm.typeSignature.typeSymbol.asClass
+        if (typeSig.fullName != "scala.Array") {
+          classLoaderMirror.runtimeClass(typeSig)
+        }
         p.name.toString -> valueFor(i)
     }: _*)
   }

--- a/src/test/scala/mesosphere/jackson/CaseClassModuleSpec.scala
+++ b/src/test/scala/mesosphere/jackson/CaseClassModuleSpec.scala
@@ -10,6 +10,8 @@ object CaseClassModuleSpec {
   case class NestedDefaults(defaults: ComplexDefaults = ComplexDefaults(Seq(5)))
   case class WithOption(n: Option[JInt])
   case class OptionDefault(x: Option[Int] = Some(5))
+  case class WithArray(a: Array[JInt])
+  case class WithArrayDefault(a: Array[JInt] = Array(1, 2, 3))
 }
 
 class CaseClassModuleSpec extends Spec with JacksonHelpers {
@@ -50,4 +52,11 @@ class CaseClassModuleSpec extends Spec with JacksonHelpers {
     deserialize[OptionDefault]("""{ "x": 5 }""") should equal (OptionDefault(Some(5)))
   }
 
+  it should "deserialize array" in {
+    deserialize[WithArray]("""{ "a": [1, 2, 3] }""").a should contain theSameElementsAs Array(1, 2, 3)
+  }
+
+  it should "respect default values for arrays" in {
+    deserialize[WithArrayDefault]("{}").a should contain theSameElementsAs Array(1, 2, 3)
+  }
 }


### PR DESCRIPTION
Problem on a case class with scala.Array deserialization
`case class WithArray(a: Array[JInt])`
```
no Java class corresponding to class Array found (through reference chain: mesosphere.jackson.WithArray["a"])
com.fasterxml.jackson.databind.JsonMappingException: no Java class corresponding to class Array found (through reference chain: mesosphere.jackson.WithArray["a"])
	at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:232)
	at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:197)
```
This is a documented behaviour of the `classLoaderMirror.runtimeClass` method
```
    /** Maps a Scala class symbol to the corresponding Java class object
     *  @throws ClassNotFoundException if there is no Java class
     *          corresponding to the given Scala class symbol.
     *  Note: If the Scala symbol is ArrayClass, a ClassNotFound exception is thrown
     *        because there is no unique Java class corresponding to a Scala generic array
     */
    def runtimeClass(cls: ClassSymbol): RuntimeClass
```