### PR TITLE
Problems on a case class with scala.Array deserialization and generic case classes deserialization

### DIFF
--- a/src/main/scala/mesosphere/jackson/CaseClassValueInstantiator.scala
+++ b/src/main/scala/mesosphere/jackson/CaseClassValueInstantiator.scala
@@ -63,8 +63,6 @@ protected class CaseClassValueInstantiator(
 
     ListMap(applySymbol.paramss.flatten.zipWithIndex.map {
       case (p, i) =>
-        val typeSig = p.asTerm.typeSignature.typeSymbol.asClass
-        val cls = classLoaderMirror.runtimeClass(typeSig)
         p.name.toString -> valueFor(i)
     }: _*)
   }

--- a/src/main/scala/mesosphere/jackson/CaseClassValueInstantiator.scala
+++ b/src/main/scala/mesosphere/jackson/CaseClassValueInstantiator.scala
@@ -63,6 +63,10 @@ protected class CaseClassValueInstantiator(
 
     ListMap(applySymbol.paramss.flatten.zipWithIndex.map {
       case (p, i) =>
+        val typeSig = p.asTerm.typeSignature.typeSymbol.asClass
+        if (typeSig.fullName != "scala.Array") {
+          classLoaderMirror.runtimeClass(typeSig)
+        }
         p.name.toString -> valueFor(i)
     }: _*)
   }

--- a/src/main/scala/mesosphere/jackson/CaseClassValueInstantiator.scala
+++ b/src/main/scala/mesosphere/jackson/CaseClassValueInstantiator.scala
@@ -63,10 +63,6 @@ protected class CaseClassValueInstantiator(
 
     ListMap(applySymbol.paramss.flatten.zipWithIndex.map {
       case (p, i) =>
-        val typeSig = p.asTerm.typeSignature.typeSymbol.asClass
-        if (typeSig.fullName != "scala.Array") {
-          classLoaderMirror.runtimeClass(typeSig)
-        }
         p.name.toString -> valueFor(i)
     }: _*)
   }

--- a/src/main/scala/mesosphere/reflect/CaseClassFactory.scala
+++ b/src/main/scala/mesosphere/reflect/CaseClassFactory.scala
@@ -11,7 +11,7 @@ protected[mesosphere] class CaseClassFactory(cls: Class[_]) {
   val classSymbol = classLoaderMirror.classSymbol(cls)
   val tpe = classSymbol.toType
 
-  if (!(tpe <:< typeOf[Product] && classSymbol.isCaseClass))
+  if (!classSymbol.isCaseClass)
     throw new IllegalArgumentException(
       "CaseClassFactory only applies to case classes!"
     )

--- a/src/test/scala/mesosphere/jackson/CaseClassModuleSpec.scala
+++ b/src/test/scala/mesosphere/jackson/CaseClassModuleSpec.scala
@@ -10,6 +10,8 @@ object CaseClassModuleSpec {
   case class NestedDefaults(defaults: ComplexDefaults = ComplexDefaults(Seq(5)))
   case class WithOption(n: Option[JInt])
   case class OptionDefault(x: Option[Int] = Some(5))
+  case class WithArray(a: Array[JInt])
+  case class WithArrayDefault(a: Array[JInt] = Array(1, 2, 3))
 }
 
 class CaseClassModuleSpec extends Spec with JacksonHelpers {
@@ -50,4 +52,11 @@ class CaseClassModuleSpec extends Spec with JacksonHelpers {
     deserialize[OptionDefault]("""{ "x": 5 }""") should equal (OptionDefault(Some(5)))
   }
 
+  it should "deserialize array" in {
+    deserialize[WithArray]("""{ "a": [1, 2, 3] }""").a should contain theSameElementsAs Array(1, 2, 3)
+  }
+
+  it should "respect default values for arrays" in {
+    deserialize[WithArrayDefault]("{}").a should contain theSameElementsAs Array(1, 2, 3)
+  }
 }

--- a/src/test/scala/mesosphere/jackson/CaseClassModuleSpec.scala
+++ b/src/test/scala/mesosphere/jackson/CaseClassModuleSpec.scala
@@ -61,7 +61,29 @@ class CaseClassModuleSpec extends Spec with JacksonHelpers {
     deserialize[WithArrayDefault]("{}").a should contain theSameElementsAs Array(1, 2, 3)
   }
 
-  it should "deserialize generic holder" in {
+  it should "deserialize generic holder with Int list" in {
     deserialize[GenericHolder[List[Int]]]("""{ "holder": [1, 2, 3]}""") should equal(GenericHolder(List(1, 2, 3)))
+  }
+
+  it should "deserialize generic holder with case class without default values" in {
+    val json = """{ "holder": [
+      |{ "name": "name1", "age": 1},
+      |{ "name": "name2", "age": 2}
+      |]}""".stripMargin
+
+    val expected = GenericHolder(List(Person("name1", 1), Person("name2", 2)))
+
+    deserialize[GenericHolder[List[Person]]](json) should equal(expected)
+  }
+
+  it should "deserialize generic holder with case class with default values" in {
+    val json = """{ "holder": [
+                 |{ "x": 1, "y": 2},
+                 |{ "z": "test"}
+                 |]}""".stripMargin
+
+    val expected = GenericHolder(Seq(Defaults(x = 1.0, y = 2.0), Defaults(z = "test")))
+
+    deserialize[GenericHolder[Seq[Defaults]]](json) should equal(expected)
   }
 }

--- a/src/test/scala/mesosphere/jackson/CaseClassModuleSpec.scala
+++ b/src/test/scala/mesosphere/jackson/CaseClassModuleSpec.scala
@@ -1,7 +1,7 @@
 package mesosphere.jackson
 
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import java.lang.{ Integer => JInt, Double => JDouble }
+import java.lang.{Double ⇒ JDouble, Integer ⇒ JInt}
 
 object CaseClassModuleSpec {
   case class Person(name: String, age: JInt)
@@ -12,6 +12,7 @@ object CaseClassModuleSpec {
   case class OptionDefault(x: Option[Int] = Some(5))
   case class WithArray(a: Array[JInt])
   case class WithArrayDefault(a: Array[JInt] = Array(1, 2, 3))
+  case class GenericHolder[T](holder: T)
 }
 
 class CaseClassModuleSpec extends Spec with JacksonHelpers {
@@ -58,5 +59,9 @@ class CaseClassModuleSpec extends Spec with JacksonHelpers {
 
   it should "respect default values for arrays" in {
     deserialize[WithArrayDefault]("{}").a should contain theSameElementsAs Array(1, 2, 3)
+  }
+
+  it should "deserialize generic holder" in {
+    deserialize[GenericHolder[List[Int]]]("""{ "holder": [1, 2, 3]}""") should equal(GenericHolder(List(1, 2, 3)))
   }
 }


### PR DESCRIPTION
Problem on a case class with scala.Array deserialization
`case class WithArray(a: Array[JInt])`

```
no Java class corresponding to class Array found (through reference chain: mesosphere.jackson.WithArray["a"])
com.fasterxml.jackson.databind.JsonMappingException: no Java class corresponding to class Array found (through reference chain: mesosphere.jackson.WithArray["a"])
    at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:232)
    at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:197)
```

This is a documented behaviour of the `classLoaderMirror.runtimeClass` method

```
    /** Maps a Scala class symbol to the corresponding Java class object
     *  @throws ClassNotFoundException if there is no Java class
     *          corresponding to the given Scala class symbol.
     *  Note: If the Scala symbol is ArrayClass, a ClassNotFound exception is thrown
     *        because there is no unique Java class corresponding to a Scala generic array
     */
    def runtimeClass(cls: ClassSymbol): RuntimeClass
```

Another problem on a generic case class deserialization
`case class GenericHolder[T](holder: T)`

```
type T is not a class (through reference chain: mesosphere.jackson.GenericHolder["holder"])
com.fasterxml.jackson.databind.JsonMappingException: type T is not a class (through reference chain: mesosphere.jackson.GenericHolder["holder"])
    at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:232)
    at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:197)
```
